### PR TITLE
Save passwords in SSHA512 and NTML format for eduroam RADIUS SQL backend

### DIFF
--- a/EDUROAM.md
+++ b/EDUROAM.md
@@ -1,0 +1,16 @@
+# samlidp and eduroam
+
+See also https://wiki.ubuntunet.net/display/EDUID/Enable+samlidp+as+eduroam+IdP+backend
+
+samlidp can easily be enhanced to act as a backend for eduroam authentication requests.
+
+These instructions have been tested with PostgreSQL.
+
+## Create additional tables for FreeRADIUS SQL module
+A script with the SQL commands to create the necessary table for FreeRADIUS v3 can be found under conf/freeradius/schema.sql
+The only change in this schema.sql compared to the original one supplied with FreeRADIUS is that `radcheck` is not a table but a view onto `idp_internal_mysql_user`.
+
+Run the script in a web ui (eg. pgAdmin4) or on the CLI. Make sure that the tables and the view belong to the same user as the tables for samlidp.
+
+If you have the database as a Docker container in the same docker compose file, you might just run this command:
+`docker-compose exec <CONTAINER_NAME> psql -f /tmp/radius-schema.sql <DATABASE_NAME> <DATABASE_USER>`

--- a/app/app/config/security.yml
+++ b/app/app/config/security.yml
@@ -1,7 +1,8 @@
 security:
     encoders:
         AppBundle\Entity\User: sha512
-        AppBundle\Entity\IdPUser: sha512
+        AppBundle\Entity\IdPUser:
+            id: appbundle.sha512salted_encoder
 
     role_hierarchy:
         ROLE_SUPER_ADMIN: ROLE_ADMIN

--- a/app/app/config/services.yml
+++ b/app/app/config/services.yml
@@ -8,6 +8,8 @@ services:
         class: AppBundle\Utils\SSPGetter
         arguments: ['@doctrine.orm.entity_manager','%database_host%','%database_name%','%database_user%','%database_password%', '%database_driver%', '%database_port%', '%samlidp_hostname%']
 
+    appbundle.sha512salted_encoder:
+        class: AppBundle\Security\Sha512Salted    
     appbundle.twofactor.google:
         class: Google\Authenticator\GoogleAuthenticator
     appbundle.twofactor.google.provider:

--- a/app/src/AppBundle/Entity/IdPUser.php
+++ b/app/src/AppBundle/Entity/IdPUser.php
@@ -6,6 +6,7 @@ use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\Encoder\PasswordEncoderInterface;
 
 /**
  * IdPUser.
@@ -45,6 +46,11 @@ class IdPUser implements UserInterface, \Serializable
      * @ORM\Column(name="password", type="string", length=255, nullable=false)
      */
     protected $password;
+
+    /**
+     * @ORM\Column(name="password_ntml", type="string", length=255, nullable=true)
+     */
+    protected $password_ntml;
 
     /**
      * @ORM\Column(name="email", type="string", length=255, nullable=false)
@@ -281,7 +287,7 @@ class IdPUser implements UserInterface, \Serializable
             } else {
                 $samlidp_hostname = substr($_SERVER['HTTP_HOST'], strpos($_SERVER['HTTP_HOST'], '.')+1);
             }
-
+            
         }
         if (!empty($this->scope)) {
             return $this->scope;
@@ -352,6 +358,20 @@ class IdPUser implements UserInterface, \Serializable
     }
 
     /**
+     * Returns the password used to authenticate the user.
+     *
+     * This should be the encoded password. On authentication, a plain-text
+     * password will be salted, encoded, and then compared to this value.
+     *
+     * @return string The password
+     */
+    public function getPassword()
+    {
+        return $this->password;
+    }
+
+    
+    /**
      * Set salt.
      *
      * @param string $salt
@@ -366,16 +386,29 @@ class IdPUser implements UserInterface, \Serializable
     }
 
     /**
-     * Returns the password used to authenticate the user.
+     * Set NTML password.
      *
-     * This should be the encoded password. On authentication, a plain-text
-     * password will be salted, encoded, and then compared to this value.
+     * @param string $password_ntml
+     *
+     * @return IdPUser
+     */
+    public function setPasswordNtml($ntml_hash)
+    {
+        $this->password_ntml = $ntml_hash;
+
+        return $this;
+    }
+
+    /**
+     * Returns the password used to authenticate the user with eduroam.
+     *
+     * This should be the NT Hash encoded password.
      *
      * @return string The password
      */
-    public function getPassword()
+    public function getPasswordNtml()
     {
-        return $this->password;
+        return $this->password_ntml;
     }
 
     /**

--- a/app/src/AppBundle/Security/Sha512Salted.php
+++ b/app/src/AppBundle/Security/Sha512Salted.php
@@ -1,0 +1,20 @@
+<?php
+namespace AppBundle\Security;
+
+use Symfony\Component\Security\Core\Encoder\PasswordEncoderInterface;
+
+class Sha512Salted implements PasswordEncoderInterface
+{
+
+    public function encodePassword($raw, $salt)
+    {
+        $digested = openssl_digest($raw . $salt, 'sha512', TRUE);
+        return base64_encode($digested . $salt);
+    }
+
+    public function isPasswordValid($encoded, $raw, $salt)
+    {
+        return $encoded === $this->encodePassword($raw, $salt);
+    }
+
+}

--- a/app/src/AppBundle/Utils/SSPGetter.php
+++ b/app/src/AppBundle/Utils/SSPGetter.php
@@ -177,6 +177,19 @@ class SSPGetter
         return $result;
     }
 
+    public function getUserSalt($username)
+    {
+        # now it handles only if username is email, but not if it comes without @scope
+        // $idpUser = $this->em->getRepository('AppBundle:IdPUser')->findOneByEmail($username);
+        if (preg_match('/@/', $username)) {
+            $idpUser = $this->em->getRepository('AppBundle:IdPUser')->findOneByEmail($username);
+        } else {
+            $idpUser = $this->em->getRepository('AppBundle:IdPUser')->findOneByUsername($username);
+        }    
+        # for production use here could come some error handling
+        return $idpUser->getSalt();      
+    }
+
     public function getAuthsources()
     {
         $config = array();

--- a/conf/freeradius/schema.sql
+++ b/conf/freeradius/schema.sql
@@ -1,0 +1,208 @@
+/*
+ *
+ * Postgresql schema for FreeRADIUS adapted for samlidp
+ *
+ */
+
+
+/*
+ * Column for password in NTML (NT hash) format
+ */
+
+-- ALTER TABLE public.idp_internal_mysql_user DROP COLUMN password_ntml;
+
+-- ALTER TABLE public.idp_internal_mysql_user
+--     ADD COLUMN password_ntml character varying(255) DEFAULT NULL;
+
+
+/*
+ * View (instead of table) for 'radcheck'
+ */
+
+-- DROP VIEW radcheck;
+
+CREATE OR REPLACE VIEW radcheck AS
+ SELECT idp_internal_mysql_user.id AS id,
+    idp_internal_mysql_user.username as UserName,
+    'NT-Password'::text AS Attribute,
+    -- 'SSHA2-512-Password'::text AS Attribute,
+    ':='::text AS op,
+    idp_internal_mysql_user.password_ntml AS Value
+    -- idp_internal_mysql_user.password AS Value
+   FROM idp_internal_mysql_user;
+
+/*
+ * Table structure for table 'radcheck'
+ */
+-- CREATE TABLE radcheck (
+-- 	id			serial PRIMARY KEY,
+-- 	UserName		text NOT NULL DEFAULT '',
+-- 	Attribute		text NOT NULL DEFAULT '',
+-- 	op			VARCHAR(2) NOT NULL DEFAULT '==',
+-- 	Value			text NOT NULL DEFAULT ''
+-- );
+
+-- create index radcheck_UserName on radcheck (UserName,Attribute);
+/*
+ * Use this index if you use case insensitive queries
+ */
+-- create index radcheck_UserName_lower on radcheck (lower(UserName),Attribute);
+
+
+/*
+ * Table structure for table 'radacct'
+ *
+ * Note: Column type bigserial does not exist prior to Postgres 7.2
+ *       If you run an older version you need to change this to serial
+ */
+CREATE TABLE radacct (
+	RadAcctId		bigserial PRIMARY KEY,
+	AcctSessionId		text NOT NULL,
+	AcctUniqueId		text NOT NULL UNIQUE,
+	UserName		text,
+	Realm			text,
+	NASIPAddress		inet NOT NULL,
+	NASPortId		text,
+	NASPortType		text,
+	AcctStartTime		timestamp with time zone,
+	AcctUpdateTime		timestamp with time zone,
+	AcctStopTime		timestamp with time zone,
+	AcctInterval		bigint,
+	AcctSessionTime		bigint,
+	AcctAuthentic		text,
+	ConnectInfo_start	text,
+	ConnectInfo_stop	text,
+	AcctInputOctets		bigint,
+	AcctOutputOctets	bigint,
+	CalledStationId		text,
+	CallingStationId	text,
+	AcctTerminateCause	text,
+	ServiceType		text,
+	FramedProtocol		text,
+	FramedIPAddress		inet
+);
+-- This index may be useful..
+-- CREATE UNIQUE INDEX radacct_whoson on radacct (AcctStartTime, nasipaddress);
+
+-- For use by update-, stop- and simul_* queries
+CREATE INDEX radacct_active_session_idx ON radacct (AcctUniqueId) WHERE AcctStopTime IS NULL;
+
+-- Add if you you regularly have to replay packets
+-- CREATE INDEX radacct_session_idx ON radacct (AcctUniqueId);
+
+-- For backwards compatibility
+-- CREATE INDEX radacct_active_user_idx ON radacct (AcctSessionId, UserName, NASIPAddress) WHERE AcctStopTime IS NULL;
+
+-- For use by onoff-
+CREATE INDEX radacct_bulk_close ON radacct (NASIPAddress, AcctStartTime) WHERE AcctStopTime IS NULL;
+
+-- and for common statistic queries:
+CREATE INDEX radacct_start_user_idx ON radacct (AcctStartTime, UserName);
+
+-- and, optionally
+-- CREATE INDEX radacct_stop_user_idx ON radacct (acctStopTime, UserName);
+
+/*
+ * There was WAAAY too many indexes previously. This combo index
+ * should take care of the most common searches.
+ * I have commented out all the old indexes, but left them in case
+ * someone wants them. I don't recomend anywone use them all at once
+ * as they will slow down your DB too much.
+ *  - pnixon 2003-07-13
+ */
+
+/*
+ * create index radacct_UserName on radacct (UserName);
+ * create index radacct_AcctSessionId on radacct (AcctSessionId);
+ * create index radacct_AcctUniqueId on radacct (AcctUniqueId);
+ * create index radacct_FramedIPAddress on radacct (FramedIPAddress);
+ * create index radacct_NASIPAddress on radacct (NASIPAddress);
+ * create index radacct_AcctStartTime on radacct (AcctStartTime);
+ * create index radacct_AcctStopTime on radacct (AcctStopTime);
+*/
+
+
+/*
+ * Table structure for table 'radgroupcheck'
+ */
+CREATE TABLE radgroupcheck (
+	id			serial PRIMARY KEY,
+	GroupName		text NOT NULL DEFAULT '',
+	Attribute		text NOT NULL DEFAULT '',
+	op			VARCHAR(2) NOT NULL DEFAULT '==',
+	Value			text NOT NULL DEFAULT ''
+);
+create index radgroupcheck_GroupName on radgroupcheck (GroupName,Attribute);
+
+/*
+ * Table structure for table 'radgroupreply'
+ */
+CREATE TABLE radgroupreply (
+	id			serial PRIMARY KEY,
+	GroupName		text NOT NULL DEFAULT '',
+	Attribute		text NOT NULL DEFAULT '',
+	op			VARCHAR(2) NOT NULL DEFAULT '=',
+	Value			text NOT NULL DEFAULT ''
+);
+create index radgroupreply_GroupName on radgroupreply (GroupName,Attribute);
+
+/*
+ * Table structure for table 'radreply'
+ */
+CREATE TABLE radreply (
+	id			serial PRIMARY KEY,
+	UserName		text NOT NULL DEFAULT '',
+	Attribute		text NOT NULL DEFAULT '',
+	op			VARCHAR(2) NOT NULL DEFAULT '=',
+	Value			text NOT NULL DEFAULT ''
+);
+create index radreply_UserName on radreply (UserName,Attribute);
+/*
+ * Use this index if you use case insensitive queries
+ */
+-- create index radreply_UserName_lower on radreply (lower(UserName),Attribute);
+
+/*
+ * Table structure for table 'radusergroup'
+ */
+CREATE TABLE radusergroup (
+	id			serial PRIMARY KEY,
+	UserName		text NOT NULL DEFAULT '',
+	GroupName		text NOT NULL DEFAULT '',
+	priority		integer NOT NULL DEFAULT 0
+);
+create index radusergroup_UserName on radusergroup (UserName);
+/*
+ * Use this index if you use case insensitive queries
+ */
+-- create index radusergroup_UserName_lower on radusergroup (lower(UserName));
+
+--
+-- Table structure for table 'radpostauth'
+--
+
+CREATE TABLE radpostauth (
+	id			bigserial PRIMARY KEY,
+	username		text NOT NULL,
+	pass			text,
+	reply			text,
+	CalledStationId		text,
+	CallingStationId	text,
+	authdate		timestamp with time zone NOT NULL default now()
+);
+
+/*
+ * Table structure for table 'nas'
+ */
+CREATE TABLE nas (
+	id			serial PRIMARY KEY,
+	nasname			text NOT NULL,
+	shortname		text NOT NULL,
+	type			text NOT NULL DEFAULT 'other',
+	ports			integer,
+	secret			text NOT NULL,
+	server			text,
+	community		text,
+	description		text
+);
+create index nas_nasname on nas (nasname);

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -1,0 +1,46 @@
+version: "3.7"
+
+services:
+  samli:
+    build:
+      context: .
+      dockerfile: Dockerfile    
+    image: samli/nren
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - storage-data:/app/web/images/idp_logo
+      # - './conf/freeradius/schema.sql:/tmp/radius-schema.sql'
+    restart: unless-stopped
+    depends_on:
+      - 'db'
+    environment:
+      - "SAMLIDP_HOSTNAME=example.eduid.africa"
+      - "VAULT_PASS=secret"
+      - "DATABASE_HOST=db.example.net"
+      - "DATABASE_PORT=5432" 
+      - "DATABASE_DRIVER=pdo_pgsql"
+      - "DATABASE_VERSION=10"
+      - "DATABASE_NAME=symfony" 
+      - "DATABASE_USER=symfony" 
+      - "DATABASE_PASSWORD=secret"
+      - "MAILER_HOST=127.0.0.1" 
+      - "MAILER_PORT=25"
+      - "MAILER_ENCRYPTION=ssl"
+      - "MAILER_USER=user" 
+      - "MAILER_PASSWORD=password"
+      - "MAILER_SENDER=noreply@example.org"
+      - "ROLLBAR_ACCESS_TOKEN=fake" 
+      - "LOGGLY_AUTH_TOKEN=fake" 
+      - "LOGGLY_TAG=samli-ssp" 
+      - "REMOTE_LOGSERVER_AND_PORT=host_or_ip:port" 
+    logging:
+      driver: "json-file"
+      #driver: "fluentd"
+      #options:
+      #  fluentd-address: 129.232.230.131:24224
+      #  tag: eduid.africa
+
+volumes:
+  storage-data:


### PR DESCRIPTION
Added another password_ntml column for IdPUser table which stores the password in NTML format. There is also a SQL schema which creates the tables that FreeRADIUS is expecting in a SQL backend.

The original password gets saved as SSHA512.