### PR TITLE
WIP: Display if IdP is in federation

### DIFF
--- a/app/src/AppBundle/Entity/Federation.php
+++ b/app/src/AppBundle/Entity/Federation.php
@@ -90,12 +90,19 @@ class Federation
     private $idps;
 
     /**
+     * @ORM\ManyToMany(targetEntity="IdP",inversedBy="federationsContaining")
+     * @ORM\JoinTable(name="federation_containing_idp")
+     */
+    private $idpsContained;
+
+    /**
      * Constructor
      */
     public function __construct()
     {
         $this->entities = new \Doctrine\Common\Collections\ArrayCollection();
         $this->idps = new \Doctrine\Common\Collections\ArrayCollection();
+        $this->idpsContained = new \Doctrine\Common\Collections\ArrayCollection();
     }
 
     public function __toString()
@@ -347,6 +354,48 @@ class Federation
     public function getIdps()
     {
         return $this->idps;
+    }
+
+    /**
+     * Add idpContained
+     *
+     * @param \AppBundle\Entity\IdP $idpContained
+     *
+     * @return Federation
+     */
+    public function addIdpContained(\AppBundle\Entity\IdP $idpContained)
+    {
+        $this->idpsContained[] = $idpContained;
+
+        return $this;
+    }
+
+    /**
+     * Remove idpContained
+     *
+     * @param \AppBundle\Entity\IdP $idpContained
+     */
+    public function removeIdpContained(\AppBundle\Entity\IdP $idpContained)
+    {
+        $this->idpsContained->removeElement($idpContained);
+    }
+
+    /**
+     * Get idpsContained
+     *
+     * @return \Doctrine\Common\Collections\Collection
+     */
+    public function getIdpsContained()
+    {
+        return $this->idpsContained;
+    }
+
+    /**
+     * Clear idpsContained
+     */
+    public function clearIdpsContained()
+    {
+        $this->idpsContained->clear();
     }
 
     /**

--- a/app/src/AppBundle/Entity/IdP.php
+++ b/app/src/AppBundle/Entity/IdP.php
@@ -113,9 +113,16 @@ class IdP
     private $entities;
 
     /**
+     * Metadata from these federations will be loaded.
      * @ORM\ManyToMany(targetEntity="Federation", mappedBy="idps")
      */
     private $federations;
+
+    /*
+     * Federations whose metadata contains this IdP
+     * @ORM\ManyToMany(targetEntity="Federation", mappedBy="idpsContained")
+     */
+    private $federationsContaining;
 
     /**
      * Constructor.
@@ -128,6 +135,7 @@ class IdP
         $this->idpAudits = new \Doctrine\Common\Collections\ArrayCollection();
         $this->domains = new \Doctrine\Common\Collections\ArrayCollection();
         $this->federations = new \Doctrine\Common\Collections\ArrayCollection();
+        $this->federationsContaining = new \Doctrine\Common\Collections\ArrayCollection();
         $this->entities = new \Doctrine\Common\Collections\ArrayCollection();
     }
 
@@ -681,6 +689,40 @@ class IdP
     public function getFederations()
     {
         return $this->federations;
+    }
+
+    /**
+     * Add federationContaining.
+     *
+     * @param \AppBundle\Entity\Federation $federationContaining
+     *
+     * @return IdP
+     */
+    public function addFederationContaining(\AppBundle\Entity\Federation $federationContaining)
+    {
+        $this->federationsContaining[] = $federationContaining;
+
+        return $this;
+    }
+
+    /**
+     * Remove federationContaining.
+     *
+     * @param \AppBundle\Entity\Federation $federationContaining
+     */
+    public function removeFederationContaining(\AppBundle\Entity\Federation $federationContaining)
+    {
+        $this->federationsContaining->removeElement($federationContaining);
+    }
+
+    /**
+     * Get federationsContaining.
+     *
+     * @return \Doctrine\Common\Collections\Collection
+     */
+    public function getFederationsContaining()
+    {
+        return $this->federationsContaining;
     }
 
     /**

--- a/app/src/AppBundle/Resources/views/Idp/idpEdit.html.twig
+++ b/app/src/AppBundle/Resources/views/Idp/idpEdit.html.twig
@@ -11,15 +11,15 @@
     {% endif %}
 
     <div class="ibox-title">
-		<h1 class="col-md-10">{% if create %}{{ "edit.create_step_second"|trans|raw }}{% else %}{{ "edit.bigtitle"|trans|raw }}{% endif %}</h1>
+        <h1 class="col-md-10">{% if create %}{{ "edit.create_step_second"|trans|raw }}{% else %}{{ "edit.bigtitle"|trans|raw }}{% endif %}</h1>
     </div>
-	<div class="ibox-content">
+    <div class="ibox-content">
         <div class="form-group">
             <div class="col-md-4"><h2 class="pull-right">{{ "edit.main_settings"|trans|raw }}</h2></div>
         </div>
         {% if not create %}
         <div class="row p-sm">
-    		<div class="text-info col-md-8 col-md-offset-4">
+            <div class="text-info col-md-8 col-md-offset-4">
                 <i class="fa fa-info m-r-sm"></i>{{ "edit.note"|trans|raw }}
                 <div class="hr-line-dashed"></div>
             </div>
@@ -204,6 +204,28 @@
                                     <input type="checkbox" {% if idp in fed.idps %}checked{% endif %} class="onoffswitch-checkbox fedlistswitch" id="{{ fed.slug }}">
                                     <label class="onoffswitch-label" for="{{ fed.slug }}"><span class="onoffswitch-inner"></span><span class="onoffswitch-switch"></span></label>
                                 </div></div>
+                                {% if fed in idp.federationsContaining %}
+                                    <span class="label label-primary">
+                                        <i class="fa fa-check-circle"></i>
+                                        In federation
+                                    </span>
+                                {% else %}
+                                    <span class="label label-warning">
+                                        <i class="fa fa-question-circle"></i>
+                                        Not in federation
+                                    </span>
+                                {% endif %}
+                                {% if idp in fed.idpsContained %}
+                                    <span class="label label-primary">
+                                        <i class="fa fa-check-circle"></i>
+                                        In federation
+                                    </span>
+                                {% else %}
+                                    <span class="label label-warning">
+                                        <i class="fa fa-question-circle"></i>
+                                        Not in federation
+                                    </span>
+                                {% endif %}
                             </td></tr>
                         {% endfor %}
                         </tbody>


### PR DESCRIPTION
# Progress:
For some reason, only one direction works of the new link between IdP and Federation:

[IdP::federationsContaining](https://github.com/totpet/samlidp/blob/2b06e30956ff075fa3d147b0ac09cc23c313a157/app/src/AppBundle/Entity/IdP.php#L123)

[Federation::idpsContained](https://github.com/totpet/samlidp/blob/2b06e30956ff075fa3d147b0ac09cc23c313a157/app/src/AppBundle/Entity/Federation.php#L93)

`fed.idpsContained` works OK, but `idp.federationsContaining` is null, see [idpEdit.html.twig#L207](https://github.com/totpet/samlidp/blob/2b06e30956ff075fa3d147b0ac09cc23c313a157/app/src/AppBundle/Resources/views/Idp/idpEdit.html.twig#L207):

![image](https://user-images.githubusercontent.com/13013768/64804267-c8a77200-d58e-11e9-86c6-d5ceaeddbf24.png)


---

I used this as a template: https://www.doctrine-project.org/projects/doctrine-orm/en/2.5/reference/association-mapping.html#many-to-many-bidirectional
